### PR TITLE
SolrConfig: heavy title boost

### DIFF
--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -139,7 +139,7 @@
         dct_subject_tmi^6
         gbl_resourceClass_tmi^6
         dct_spatial_tmi^8
-        dct_title_ti^9
+        dct_title_ti^70
         geomg_s_ti^10
       </str>
       <str name="pf"><!-- phrase boost within result set -->
@@ -152,15 +152,15 @@
         dct_subject_tmi^6
         gbl_resourceClass_tmi^6
         dct_spatial_tmi^8
-        dct_title_ti^9
+        dct_title_ti^70
         geomg_s_ti^10
       </str>
       <str name="title_qf">
-        dct_title_ti^10
+        dct_title_ti^70
         dct_isPartOf_tmi
       </str>
       <str name="title_pf">
-        dct_title_ti^10
+        dct_title_ti^70
         dct_isPartOf_tmi
       </str>
       <str name="publisher_qf">


### PR DESCRIPTION
Improve keyword-only search results, by heavily boosting title field hits to the top of the result list.

